### PR TITLE
Support `deliver_later` and `deliver_now`

### DIFF
--- a/lib/solidus_sendwithus/message.rb
+++ b/lib/solidus_sendwithus/message.rb
@@ -4,7 +4,7 @@ module Spree
   module SendWithUs
     class Message
       attr_reader :to, :from, :email_id, :email_data, :cc, :bcc, :files,
-        :esp_account, :tags, :locale, :version_name
+                  :esp_account, :tags, :locale, :version_name
 
       def initialize
         @email_data = {}
@@ -56,7 +56,7 @@ module Spree
         end
       end
 
-      def deliver
+      def mail_sendwithus(&args)
         ::SendWithUs::Api.new.send_email(
           @email_id,
           @to,
@@ -72,6 +72,31 @@ module Spree
             version_name: @version_name
           }
         )
+      end
+
+      alias_method :deliver_later!, :mail_sendwithus
+      alias_method :deliver_later,  :mail_sendwithus
+      alias_method :deliver_now!,   :mail_sendwithus
+      alias_method :deliver_now,    :mail_sendwithus
+
+      def deliver! #:nodoc:
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          `#deliver!` is deprecated and will be removed in Rails 5. Use
+          `#deliver_now!` to deliver immediately or `#deliver_later!` to
+          deliver through Active Job.
+        MSG
+
+        deliver_now!
+      end
+
+      def deliver #:nodoc:
+        ActiveSupport::Deprecation.warn(<<-MSG.squish)
+          `#deliver` is deprecated and will be removed in Rails 5. Use
+          `#deliver_now` to deliver immediately or `#deliver_later` to
+          deliver through Active Job.
+        MSG
+
+        deliver_now
       end
     end
   end

--- a/spec/lib/solidus_sendwithus/message_spec.rb
+++ b/spec/lib/solidus_sendwithus/message_spec.rb
@@ -3,7 +3,18 @@ require 'solidus_sendwithus'
 describe Spree::SendWithUs::Message do
   subject { Spree::SendWithUs::Message.new }
 
-  it { is_expected.to respond_to(:email_id, :to, :from, :cc, :bcc, :deliver) }
+  it do
+    is_expected.to respond_to(:email_id,
+                              :to,
+                              :from,
+                              :cc,
+                              :bcc,
+                              :deliver,
+                              :deliver_now,
+                              :deliver_now!,
+                              :deliver_later,
+                              :deliver_later)
+  end
   it { is_expected.not_to respond_to(:email_id=, :to=, :from=, :cc=, :bcc=) }
 
   describe "initialization" do
@@ -107,14 +118,14 @@ describe Spree::SendWithUs::Message do
     end
   end
 
-  describe "#deliver" do
+  describe "#deliver_now" do
     let(:api_double) { double("api") }
 
     it "calls the send_with_us gem" do
       allow(SendWithUs::Api).to receive(:new).and_return(api_double)
       expect(api_double).to receive(:send_email)
 
-      subject.deliver
+      subject.deliver_now
     end
   end
 end


### PR DESCRIPTION
`deliver` is removed from rails 5. Add `deliver_later` and
`deliver_now` and deprecate `deliver` method.